### PR TITLE
feat: Add e2b div command for code diff analysis

### DIFF
--- a/lib/n2b.rb
+++ b/lib/n2b.rb
@@ -9,12 +9,12 @@ require 'n2b/version'
 require 'n2b/llm/claude'
 require 'n2b/llm/open_ai'
 require 'n2b/llm/gemini'
+require 'n2b/errors' # Load custom errors
 require 'n2b/base'
 require 'n2b/cli'
 
 require 'n2b/irb'
 
 module N2B
-  class Error < StandardError; end
-
+  # Error class is now defined in n2b/errors.rb
 end

--- a/lib/n2b/cli.rb
+++ b/lib/n2b/cli.rb
@@ -12,11 +12,36 @@ module N2B
     def execute
       config = get_config(reconfigure: @options[:config])
       input_text = @args.join(' ')
-      if input_text.empty?
+      if @args.first == 'div'
+        unless is_git_repository?
+          puts "Error: Not a git repository."
+          exit 1 # Consider how to test exit calls, or if it should raise an exception for easier testing.
+        end
+
+        diff_output = execute_git_diff
+        analyze_diff(diff_output, config)
+      elsif input_text.empty?
         puts "Enter your natural language command:"
         input_text = $stdin.gets.chomp
+        process_natural_language_command(input_text, config)
+      else
+        process_natural_language_command(input_text, config)
       end
+    end
 
+    protected # Changed to protected for easier testing/mocking if necessary, or keep private and test differently
+
+    def is_git_repository?
+      system('git rev-parse --is-inside-work-tree', out: File::NULL, err: File::NULL)
+    end
+
+    def execute_git_diff
+      `git diff HEAD`
+    end
+
+    private
+
+    def process_natural_language_command(input_text, config)
       bash_commands = call_llm(input_text, config)
 
       puts "\nTranslated #{get_user_shell} Commands:"
@@ -24,10 +49,10 @@ module N2B
       puts bash_commands['commands']
       puts "------------------------"
       if bash_commands['explanation']
-        puts "Explanation:" 
+        puts "Explanation:"
         puts bash_commands['explanation']
         puts "------------------------"
-      end 
+      end
 
       if @options[:execute]
         puts "Press Enter to execute these commands, or Ctrl+C to cancel."
@@ -38,9 +63,58 @@ module N2B
       end
     end
 
-    private
+    def analyze_diff(diff_output, config)
+      prompt = <<-PROMPT
+Please analyze the following code diff. Provide:
+1. A concise summary of the changes.
+2. A list of potential errors or bugs.
+3. Suggestions for improvements or best practices.
 
-    
+Return the analysis as a JSON object with the keys "summary", "errors", and "improvements".
+
+Diff:
+```
+#{diff_output}
+```
+PROMPT
+
+      analysis_json_str = call_llm_for_diff_analysis(prompt, config)
+
+      begin
+        analysis_result = JSON.parse(analysis_json_str)
+
+        puts "\nCode Diff Analysis:"
+        puts "-------------------"
+        puts "Summary:"
+        puts analysis_result['summary'] || "No summary provided."
+        puts "\nPotential Errors:"
+        errors_list = analysis_result['errors']
+        errors_list = [errors_list] if errors_list.is_a?(String) && !errors_list.empty?
+        errors_list = [] if errors_list.nil? || (errors_list.is_a?(String) && errors_list.empty?)
+        puts errors_list.any? ? errors_list.map{|err| "- #{err}"}.join("\n") : "No errors identified."
+
+        puts "\nSuggested Improvements:"
+        improvements_list = analysis_result['improvements']
+        improvements_list = [improvements_list] if improvements_list.is_a?(String) && !improvements_list.empty?
+        improvements_list = [] if improvements_list.nil? || (improvements_list.is_a?(String) && improvements_list.empty?)
+        puts improvements_list.any? ? improvements_list.map{|imp| "- #{imp}"}.join("\n") : "No improvements suggested."
+        puts "-------------------"
+      rescue JSON::ParserError => e # Handles cases where the JSON string (even fallback) is malformed
+        puts "Critical Error: Failed to parse JSON response for diff analysis: #{e.message}"
+        puts "Raw response was: #{analysis_json_str}"
+      end
+    end
+
+    def call_llm_for_diff_analysis(prompt, config)
+      begin
+        llm = config['llm'] == 'openai' ? N2M::Llm::OpenAi.new(config) : N2M::Llm::Claude.new(config)
+        response_json_str = llm.make_request(prompt)
+        response_json_str
+      rescue N2B::LlmApiError => e
+        puts "Error communicating with the LLM: #{e.message}"
+        return '{"summary": "Error: Could not analyze diff due to LLM API error.", "errors": [], "improvements": []}'
+      end
+    end
     
     def append_to_llm_history_file(commands)
       File.open(HISTORY_FILE, 'a') do |file|
@@ -56,10 +130,11 @@ module N2B
     end
     
     def call_llm(prompt, config)
-      
-      llm = config['llm'] == 'openai' ?   N2M::Llm::OpenAi.new(config) : N2M::Llm::Claude.new(config)
-      
-      content = <<-EOF 
+      begin # Added begin for LlmApiError rescue
+        llm = config['llm'] == 'openai' ?   N2M::Llm::OpenAi.new(config) : N2M::Llm::Claude.new(config)
+
+        # This content is specific to bash command generation
+      content = <<-EOF
               Translate the following natural language command to bash commands: #{prompt}\n\nProvide only the #{get_user_shell} commands for #{ get_user_os }. the commands should be separated by newlines. 
               #{' the user is in directory'+Dir.pwd if config['privacy']['send_current_directory']}. 
               #{' the user sent past requests to you and got these answers '+read_llm_history_file if config['privacy']['send_llm_history'] }
@@ -70,10 +145,27 @@ module N2B
               EOF
     
            
-      answer = llm.make_request(content)
+      response_json_str = llm.make_request(content)
 
-      append_to_llm_history_file("#{prompt}\n#{answer}")
-      answer
+      append_to_llm_history_file("#{prompt}\n#{response_json_str}") # Storing the raw JSON string
+      # The original call_llm was expected to return a hash after JSON.parse,
+      # but it was actually returning the string. Let's assume it should return a parsed Hash.
+      # However, the calling method `process_natural_language_command` accesses it like `bash_commands['commands']`
+      # which implies it expects a Hash. Let's ensure call_llm returns a Hash.
+      # This internal JSON parsing is for the *content* of a successful LLM response.
+      # The LlmApiError for network/auth issues should be caught before this.
+      begin
+        parsed_response = JSON.parse(response_json_str)
+        parsed_response
+      rescue JSON::ParserError => e
+        puts "Error parsing LLM response JSON for command generation: #{e.message}"
+        # This is a fallback for when the LLM response *content* is not valid JSON.
+        { "commands" => ["echo 'Error: LLM returned invalid JSON content.'"], "explanation" => "The response from the language model was not valid JSON." }
+      end
+    rescue N2B::LlmApiError => e
+      puts "Error communicating with the LLM: #{e.message}"
+      # This is the fallback for LlmApiError (network, auth, etc.)
+      { "commands" => ["echo 'LLM API error occurred. Please check your configuration and network.'"], "explanation" => "Failed to connect to the LLM." }
     end
     
     def get_user_shell

--- a/lib/n2b/errors.rb
+++ b/lib/n2b/errors.rb
@@ -1,0 +1,7 @@
+module N2B
+  class Error < StandardError
+  end
+
+  class LlmApiError < Error
+  end
+end

--- a/lib/n2b/llm/claude.rb
+++ b/lib/n2b/llm/claude.rb
@@ -31,12 +31,12 @@ module N2M
         end
         # check for errors
         if response.code != '200'
-          puts "Error: #{response.code} #{response.message}"
-          puts response.body
-          exit 1
+          raise N2B::LlmApiError.new("LLM API Error: #{response.code} #{response.message} - #{response.body}")
         end
         answer = JSON.parse(response.body)['content'].first['text'] 
         begin 
+          # The llm_response.json file is likely for debugging and can be kept or removed.
+          # For this refactoring, I'll keep it as it doesn't affect the error handling logic.
           File.open('llm_response.json', 'w') do |f|
             f.write(answer)
           end
@@ -46,13 +46,17 @@ module N2M
           # gsub all \n with \\n that are inside "
           # 
           answer.gsub!(/"([^"]*)"/) { |match| match.gsub(/\n/, "\\n") }
+          # The llm_response.json file is likely for debugging and can be kept or removed.
           File.open('llm_response.json', 'w') do |f|
             f.write(answer)
           end
           answer = JSON.parse(answer)
         rescue JSON::ParserError
-          puts "Error parsing JSON: #{answer}"
-          answer = { 'explanation' => answer}
+          # This specific JSON parsing error is about the LLM's *response content*, not an API error.
+          # It should probably be handled differently, but the subtask is about LlmApiError.
+          # For now, keeping existing behavior for this part.
+          puts "Error parsing JSON from LLM response: #{answer}" # Clarified error message
+          answer = { 'explanation' => answer} # Default fallback
         end
         answer
       end

--- a/lib/n2b/llm/gemini.rb
+++ b/lib/n2b/llm/gemini.rb
@@ -35,10 +35,7 @@ module N2M
 
         # check for errors
         if response.code != '200'
-          puts "Error: #{response.code} #{response.message}"
-          puts response.body
-          puts "Config: #{@config.inspect}"
-          exit 1
+          raise N2B::LlmApiError.new("LLM API Error: #{response.code} #{response.message} - #{response.body}")
         end
 
         parsed_response = JSON.parse(response.body)

--- a/lib/n2b/llm/open_ai.rb
+++ b/lib/n2b/llm/open_ai.rb
@@ -33,9 +33,7 @@ module N2M
 
         # check for errors
         if response.code != '200'
-          puts "Error: #{response.code} #{response.message}"
-          puts response.body
-          exit 1
+          raise N2B::LlmApiError.new("LLM API Error: #{response.code} #{response.message} - #{response.body}")
         end
         answer = JSON.parse(response.body)['choices'].first['message']['content']
         begin

--- a/test/n2b/cli_test.rb
+++ b/test/n2b/cli_test.rb
@@ -1,0 +1,195 @@
+require 'test_helper' # Assumes test_helper.rb exists and sets up load paths correctly
+require 'n2b/cli'
+require 'minitest/autorun'
+require 'mocha/minitest'
+require 'fileutils'
+require 'stringio' # To capture stdout
+require 'json'     # For .to_json
+
+# Stubbing dependent classes if not loaded by test_helper for robustness in testing environment.
+# Ideally, test_helper.rb or the main library file (e.g., n2b.rb) would ensure all dependencies are loaded.
+if !defined?(N2M::Llm::OpenAi)
+  module N2M; module Llm; class OpenAi; def initialize(config); end; def make_request(prompt); ""; end; end; end; end
+end
+if !defined?(N2M::Llm::Claude)
+  module N2M; module Llm; class Claude; def initialize(config); end; def make_request(prompt); ""; end; end; end; end
+end
+if !defined?(N2B::Base) # Assuming CLI inherits from Base or uses it.
+  module N2B
+    class Base
+      # Define a basic get_config if CLI instances call it (e.g., super in initialize or directly)
+      def get_config(reconfigure: false)
+        {
+          'llm' => 'openai', # Default mock
+          'privacy' => {
+            'send_current_directory' => false,
+            'send_llm_history' => false,
+            'send_shell_history' => false
+          },
+          'append_to_shell_history' => false
+        }
+      end
+    end
+  end
+end
+
+
+module N2B
+  class CLITest < Minitest::Test
+    def setup
+      @tmp_dir = File.expand_path("./tmp_test_n2b_cli_dir", Dir.pwd) # Ensure tmp dir is uniquely named and local
+      FileUtils.mkdir_p(@tmp_dir)
+
+      @original_stdout = $stdout
+      $stdout = StringIO.new
+      @original_stderr = $stderr
+      $stderr = StringIO.new
+
+      # Centralized config stubbing for all tests
+      @mock_config = {
+        'llm' => 'openai',
+        'privacy' => {
+          'send_current_directory' => false,
+          'send_llm_history' => false,
+          'send_shell_history' => false
+        },
+        'append_to_shell_history' => false,
+        # Ensure any other expected keys by N2B::CLI's get_config/config usage are present
+      }
+      # Stub get_config for any instance of CLI that might be created.
+      # This avoids issues if Base#get_config is more complex or if CLI overrides it.
+      N2B::CLI.any_instance.stubs(:get_config).returns(@mock_config)
+    end
+
+    def teardown
+      FileUtils.rm_rf(@tmp_dir)
+      $stdout = @original_stdout
+      $stderr = @original_stderr
+    end
+
+    def test_div_not_a_git_repository
+      Dir.chdir(@tmp_dir) do
+        cli_instance = N2B::CLI.new(['div'])
+        # Ensure the instance uses the mocked methods
+        cli_instance.stubs(:is_git_repository?).returns(false)
+
+        ex = assert_raises(SystemExit) { cli_instance.execute }
+
+        $stdout.rewind
+        output = $stdout.string
+        assert_match "Error: Not a git repository.", output
+        assert_equal 1, ex.status
+      end
+    end
+
+    def test_div_git_repository_no_changes
+      Dir.chdir(@tmp_dir) do
+        system("git init -q .", chdir: @tmp_dir) # Run git init in the temp dir
+
+        cli_instance = N2B::CLI.new(['div'])
+        cli_instance.stubs(:is_git_repository?).returns(true)
+        cli_instance.stubs(:execute_git_diff).returns("") # No changes
+
+        expected_llm_response = {
+          "summary" => "No changes found in the diff.",
+          "errors" => [],
+          "improvements" => []
+        }.to_json # Ensure it's a JSON string, as expected by analyze_diff
+
+        cli_instance.expects(:call_llm_for_diff_analysis)
+          .with(regexp_matches(/Diff:\n```\n\n```/m), @mock_config) # also check config is passed
+          .returns(expected_llm_response)
+
+        cli_instance.execute
+        $stdout.rewind
+        actual_output = $stdout.string
+
+        assert_match "Summary:\nNo changes found in the diff.", actual_output
+        assert_match "Potential Errors:\nNo errors identified.", actual_output
+        assert_match "Suggested Improvements:\nNo improvements suggested.", actual_output
+      end
+    end
+
+    def test_div_git_repository_with_changes
+      Dir.chdir(@tmp_dir) do
+        system("git init -q .", chdir: @tmp_dir)
+        File.write(File.join(@tmp_dir, "test_file.txt"), "initial content\n")
+        system("git add test_file.txt && git commit -m 'initial commit' -q", chdir: @tmp_dir)
+        File.write(File.join(@tmp_dir, "test_file.txt"), "modified content\n")
+
+        sample_diff = "diff --git a/test_file.txt b/test_file.txt\nindex <hash_a>..<hash_b> 100644\n--- a/test_file.txt\n+++ b/test_file.txt\n@@ -1 +1 @@\n-initial content\n+modified content\n"
+
+        cli_instance = N2B::CLI.new(['div'])
+        cli_instance.stubs(:is_git_repository?).returns(true)
+        cli_instance.stubs(:execute_git_diff).returns(sample_diff)
+
+        llm_response = {
+          "summary" => "Modified test_file.txt",
+          "errors" => ["One potential error identified."],
+          "improvements" => ["Consider adding comments."]
+        }.to_json # JSON string
+
+        cli_instance.expects(:call_llm_for_diff_analysis)
+          .with(regexp_matches(/#{Regexp.escape(sample_diff)}/m), @mock_config)
+          .returns(llm_response)
+
+        cli_instance.execute
+        $stdout.rewind
+        actual_output = $stdout.string
+
+        assert_match "Summary:\nModified test_file.txt", actual_output
+        # For arrays, assert that each item is present if they are printed on separate lines or similar
+        assert_match "Potential Errors:\n- One potential error identified.", actual_output
+        assert_match "Suggested Improvements:\n- Consider adding comments.", actual_output
+      end
+    end
+
+    def test_div_llm_api_error
+      Dir.chdir(@tmp_dir) do
+        system("git init -q .", chdir: @tmp_dir)
+        File.write(File.join(@tmp_dir, "test_file.txt"), "initial content\n")
+        system("git add test_file.txt && git commit -m 'initial commit' -q", chdir: @tmp_dir)
+        File.write(File.join(@tmp_dir, "test_file.txt"), "modified content\n")
+
+        sample_diff = "diff --git a/test_file.txt b/test_file.txt\nindex <hash_a>..<hash_b> 100644\n--- a/test_file.txt\n+++ b/test_file.txt\n@@ -1 +1 @@\n-initial content\n+modified content\n"
+
+        cli_instance = N2B::CLI.new(['div'])
+        cli_instance.stubs(:is_git_repository?).returns(true)
+        cli_instance.stubs(:execute_git_diff).returns(sample_diff)
+
+        # Simulate LlmApiError being raised from within call_llm_for_diff_analysis
+        # The method itself will catch this, print a message, and return fallback JSON.
+        # So, we mock the underlying llm.make_request (via the N2M::Llm::OpenAi/Claude new.make_request chain)
+        # or more directly, mock `call_llm_for_diff_analysis` itself if it didn't have the rescue logic.
+        # Since the rescue logic IS in `call_llm_for_diff_analysis`, we need to test that it behaves as expected.
+        # We can mock the `llm.make_request` part that's *inside* `call_llm_for_diff_analysis`.
+
+        # To do this, we expect N2M::Llm::OpenAi (or Claude, based on @mock_config) to be instantiated,
+        # and its make_request method to be called.
+        mock_llm_instance = mock('llm_instance')
+        mock_llm_instance.expects(:make_request)
+          .with(regexp_matches(/#{Regexp.escape(sample_diff)}/m))
+          .raises(N2B::LlmApiError.new("Simulated API Error: Connection refused"))
+
+        # Ensure the correct LLM class is instantiated and returns our mock LLM instance
+        if @mock_config['llm'] == 'openai'
+          N2M::Llm::OpenAi.expects(:new).with(@mock_config).returns(mock_llm_instance)
+        else # claude
+          N2M::Llm::Claude.expects(:new).with(@mock_config).returns(mock_llm_instance)
+        end
+
+        cli_instance.execute
+        $stdout.rewind
+        actual_output = $stdout.string
+
+        # Check for the user-friendly message printed when LlmApiError is rescued
+        assert_match "Error communicating with the LLM: Simulated API Error: Connection refused", actual_output
+
+        # Check for the fallback summary printed by analyze_diff after parsing the fallback JSON
+        assert_match "Summary:\nError: Could not analyze diff due to LLM API error.", actual_output
+        assert_match "Potential Errors:\nNo errors identified.", actual_output
+        assert_match "Suggested Improvements:\nNo improvements suggested.", actual_output
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit introduces a new `e2b div` command to the N2B CLI. This command allows you to get an AI-powered analysis of your current git diff.

Key features and changes:

- **New `div` command in `N2B::CLI`**:
    - Checks if the current directory is a git repository.
    - Captures the output of `git diff HEAD`.
    - Sends the diff to an LLM for analysis (summary, potential errors, suggested improvements).
    - Displays the formatted analysis to you.

- **LLM Interaction for Diff Analysis**:
    - A new method `call_llm_for_diff_analysis` was added to handle LLM communication specifically for diff analysis, instructing the LLM to return a JSON response.
    - The existing `call_llm` method was updated to parse JSON responses for bash command generation.

- **Improved Error Handling**:
    - Introduced custom error classes `N2B::Error` and `N2B::LlmApiError`.
    - LLM client classes now raise `N2B::LlmApiError` on API failures instead of exiting.
    - The CLI now catches `N2B::LlmApiError` and provides user-friendly error messages and fallback responses.

- **Testability Refactor**:
    - System calls for `git rev-parse` and `git diff` in the CLI were extracted into protected methods (`is_git_repository?` and `execute_git_diff`) to facilitate easier mocking in tests.

- **Comprehensive Test Coverage**:
    - Added `test/n2b/cli_test.rb` with tests for the `div` command: - Non-git repository scenario. - Git repository with no changes. - Git repository with changes. - LLM API error during analysis.